### PR TITLE
Update config url

### DIFF
--- a/xdevbot/routes.py
+++ b/xdevbot/routes.py
@@ -6,7 +6,7 @@ from xdevbot import github, projects, queries, utils
 
 logger = logging.getLogger('gunicorn.error')
 
-CONFIG_URL = 'https://raw.githubusercontent.com/NCAR/xdev/master/xdevbot.yaml'
+CONFIG_URL = 'https://raw.githubusercontent.com/NCAR/xdev/xdevbot/xdevbot.yaml'
 
 
 async def github_handler(request: web.Request) -> web.Response:


### PR DESCRIPTION
The bot was still using the config file from the master branch, and was running into errors (since I delete the config file from the master branch). This PR updates the config url to the xdevbot branch. 